### PR TITLE
Add configurable retry to the price fetch

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,5 +3,6 @@
     "maxIncreaseMult": 10,
     "maxLimiter": false,
     "pvePrices": false,
+    "maxRetries": 3,
     "debug": false
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -11,7 +11,7 @@ import { ConfigTypes } from "@spt/models/enums/ConfigTypes";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-class Mod implements IPostDBLoadModAsync 
+class Mod implements IPostDBLoadModAsync
 {
     private static container: DependencyContainer;
     private static updateTimer: NodeJS.Timeout;
@@ -38,12 +38,12 @@ class Mod implements IPostDBLoadModAsync
         // Update prices on startup
         const currentTime = Math.floor(Date.now() / 1000);
         let fetchPrices = false;
-        if (currentTime > Mod.config.nextUpdate) 
+        if (currentTime > Mod.config.nextUpdate)
         {
             fetchPrices = true;
         }
 
-        if (!await Mod.updatePrices(fetchPrices)) 
+        if (!await Mod.updatePrices(fetchPrices))
         {
             return;
         }
@@ -52,7 +52,7 @@ class Mod implements IPostDBLoadModAsync
         Mod.updateTimer = setInterval(Mod.updatePrices, (60 * 60 * 1000));
     }
 
-    static async updatePrices(fetchPrices = true): Promise<boolean> 
+    static async updatePrices(fetchPrices = true): Promise<boolean>
     {
         const logger = Mod.container.resolve<ILogger>("WinstonLogger");
         const databaseServer = Mod.container.resolve<DatabaseServer>("DatabaseServer");
@@ -67,7 +67,7 @@ class Mod implements IPostDBLoadModAsync
         let prices: Record<string, number>;
 
         // Fetch the latest prices.json if we're triggered with fetch enabled, or the prices file doesn't exist
-        if (fetchPrices || !fs.existsSync(Mod.pricesPath)) 
+        if (fetchPrices || !fs.existsSync(Mod.pricesPath))
         {
             logger.info(`[LiveFleaPrices] Fetching Flea Prices for gamemode ${gameMode}...`);
 
@@ -121,25 +121,25 @@ class Mod implements IPostDBLoadModAsync
             fs.writeFileSync(Mod.configPath, JSON.stringify(Mod.config, null, 4));
         }
         // Otherwise, read the file from disk
-        else 
+        else
         {
             logger.info(`[LiveFleaPrices] Using cached prices.`);
             prices = JSON.parse(fs.readFileSync(Mod.pricesPath, "utf-8"));
         }
 
         // Loop through the new prices file, updating all prices present
-        for (const itemId in prices) 
+        for (const itemId in prices)
         {
             // Skip any price that doesn't exist in the item table
-            if (!itemTable[itemId]) 
+            if (!itemTable[itemId])
             {
                 continue;
             }
 
             // Skip any item that's blacklisted
-            if (Mod.blacklist.includes(itemId)) 
+            if (Mod.blacklist.includes(itemId))
             {
-                if (Mod.config.debug) 
+                if (Mod.config.debug)
                 {
                     logger.debug(`[LiveFleaPrices] Item ${itemId} was skipped due to it being blacklisted.`);
                 }
@@ -147,19 +147,19 @@ class Mod implements IPostDBLoadModAsync
             }
 
             let basePrice = Mod.originalPrices[itemId];
-            if (!basePrice) 
+            if (!basePrice)
             {
                 basePrice = handbookTable.Items.find(x => x.Id === itemId)?.Price ?? 0;
             }
 
             const maxPrice = basePrice * Mod.config.maxIncreaseMult;
-            if (maxPrice !== 0 && (!Mod.config.maxLimiter || prices[itemId] <= maxPrice)) 
+            if (maxPrice !== 0 && (!Mod.config.maxLimiter || prices[itemId] <= maxPrice))
             {
                 priceTable[itemId] = prices[itemId];
             }
-            else 
+            else
             {
-                if (Mod.config.debug) 
+                if (Mod.config.debug)
                 {
                     logger.debug(`[LiveFleaPrices] Setting ${itemId} to ${maxPrice} instead of ${prices[itemId]} due to over inflation`);
                 }
@@ -167,14 +167,14 @@ class Mod implements IPostDBLoadModAsync
             }
 
             // Special handling in the event `useTraderPriceForOffersIfHigher` is enabled, to fix issues selling items
-            if (ragfairConfig.dynamic.useTraderPriceForOffersIfHigher) 
+            if (ragfairConfig.dynamic.useTraderPriceForOffersIfHigher)
             {
                 // If the trader price is greater than the flea price, set the flea price to 10% higher than the trader price
                 const traderPrice = traderHelper.getHighestSellToTraderPrice(itemId);
-                if (traderPrice > priceTable[itemId]) 
+                if (traderPrice > priceTable[itemId])
                 {
                     const newPrice = Math.floor(traderPrice * 1.1);
-                    if (Mod.config.debug) 
+                    if (Mod.config.debug)
                     {
                         logger.debug(`[LiveFleaPrices] Setting ${itemId} to ${newPrice} instead of ${prices[itemId]} due to trader price`);
                     }
@@ -190,7 +190,7 @@ class Mod implements IPostDBLoadModAsync
     }
 }
 
-interface Config 
+interface Config
 {
     nextUpdate: number,
     maxIncreaseMult: number,


### PR DESCRIPTION
I have encountered random fetch failures when pulling the prices from Github, there doesn't seem to be any discernable pattern I could reproduce or diagnose. From scrolling Discord, this seems to be a somewhat common issue.

- Adds a configurable retry via `maxRetries`
- Adds `[LiveFleaPrices]` to logging to make server logs easier to debug

Example log from a live retry
```
[LiveFleaPrices] Fetching Flea Prices for gamemode regular...
[LiveFleaPrices] Fetch attempt 1 failed with error: fetch failed, retrying...
[LiveFleaPrices] Fetch attempt 2 successful.
[LiveFleaPrices] Next price update scheduled for: 1/22/2025, 2:33:19 PM
```