### PR TITLE
Add multipliers feature

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -139,15 +139,20 @@ class Mod implements IPostSptLoadModAsync
             }
 
             const maxPrice = basePrice * Mod.config.maxIncreaseMult;
-            if (maxPrice !== 0 && (!Mod.config.maxLimiter || prices[itemId] <= maxPrice))
+            const multiplier =
+              Mod.config.multipliers && Mod.config.multipliers[itemId]
+                ? Mod.config.multipliers[itemId]
+                : 1;
+            const itemPrice = Math.floor(prices[itemId] * multiplier);
+            if (maxPrice !== 0 && (!Mod.config.maxLimiter || itemPrice <= maxPrice))
             {
-                priceTable[itemId] = prices[itemId];
+                priceTable[itemId] = itemPrice;
             }
             else
             {
                 if (Mod.config.debug)
                 {
-                    logger.debug(`[LiveFleaPrices] Setting ${itemId} to ${maxPrice} instead of ${prices[itemId]} due to over inflation`);
+                    logger.debug(`[LiveFleaPrices] Setting ${itemId} to ${maxPrice} instead of ${itemPrice} due to over inflation`);
                 }
                 priceTable[itemId] = maxPrice;
             }
@@ -162,7 +167,7 @@ class Mod implements IPostSptLoadModAsync
                     const newPrice = Math.floor(traderPrice * 1.1);
                     if (Mod.config.debug)
                     {
-                        logger.debug(`[LiveFleaPrices] Setting ${itemId} to ${newPrice} instead of ${prices[itemId]} due to trader price`);
+                        logger.debug(`[LiveFleaPrices] Setting ${itemId} to ${newPrice} instead of ${itemPrice} due to trader price`);
                     }
                     priceTable[itemId] = newPrice;
                 }
@@ -183,6 +188,7 @@ interface Config
     maxLimiter: boolean,
     pvePrices: boolean,
     debug: boolean,
+    multipliers?: Record<string, number>,
 }
 
 module.exports = { mod: new Mod() }


### PR DESCRIPTION
## Description
I've added [Old Colored Keycards](https://hub.sp-tarkov.com/files/file/2632-old-colored-keycards/) mod.

To ensure compatibility with Live Flea Prices, Old Colored Keycards has opted to add specific keys to ``blacklist.json`` and manually adjust their prices. This approach serves as a temporary solution, however, given that the live flea market is dynamic and constantly changing, assigning fixed prices to items within any mod may lead to inconsistencies in reflecting the true value of these items in the broader market context.

Consequently, I add the multipliers feature. This feature enables any mod to dynamically adjust prices to better represent the value of their items.

## Usage
The multipliers feature supports an optional ``multipliers`` property(Type: ``Record<string, number>``) in ``config.json``. Users and other mods can manually specify item IDs along with their respective price multipliers.

For instance, a ``multipliers`` property include TerraGroup Labs keycard (Blue) with a multiplier of 10 and TerraGroup Labs keycard (Red) with a multiplier of 9 should be:
``` json
"multipliers": {
  "5c1d0c5f86f7744bb2683cf0": 10,
  "5c1d0efb86f7744baf2e7b7b": 9
}
```
the whole ``config.json``:
``` json
{
    "nextUpdate": 0,
    "maxIncreaseMult": 10,
    "maxIncreaseMult": 10,
    "maxLimiter": false,
    "pvePrices": false,
    "debug": false,
    "multipliers": {
        "5c1d0c5f86f7744bb2683cf0": 10,
        "5c1d0efb86f7744baf2e7b7b": 9
    }
}
```
